### PR TITLE
typo fixes

### DIFF
--- a/dapr1_lectures/dapR1_lec16_onesamplet.Rmd
+++ b/dapr1_lectures/dapR1_lec16_onesamplet.Rmd
@@ -810,7 +810,7 @@ class: inverse, center, middle
 
 - The basic form of $D$ is the same across the different $t$-tests:
 
-$$D = \frac{Differece}{Variation}$$
+$$D = \frac{Difference}{Variation}$$
 
 ---
 # Interpreting Cohen's D

--- a/dapr1_lectures/dapR1_lec20_Correlation.Rmd
+++ b/dapr1_lectures/dapR1_lec20_Correlation.Rmd
@@ -139,7 +139,7 @@ class: inverse, center, middle
 
 # Running Program
 
-- Suppose a running coach wants to know whether there is an association between a participants' time spent enrolled in their running program (recorded in days) and the maximum distance they can run (receded in miles)  
+- Suppose a running coach wants to know whether there is an association between a participants' time spent enrolled in their running program (recorded in days) and the maximum distance they can run (recorded in miles)  
 
 - We are provided with information on the last 100 participants to enroll on the program
 
@@ -1002,7 +1002,7 @@ class: inverse, center, middle
 
 # Hypotheses
 
-+ There may be times that a correlation is the test of interest, and we can formulate associated hypotheses tests
++ There may be times that a correlation is the test of interest, and we can formulate associated hypothesis tests
 
 + There is no association between two random variables, so the null hypothesis should reflect this:
 

--- a/dapr1_lectures/dapr1_2_01_confint/dapr1_2_01_confint.Rmd
+++ b/dapr1_lectures/dapr1_2_01_confint/dapr1_2_01_confint.Rmd
@@ -566,7 +566,7 @@ $$
 
 --
 
-- Because we didn't know $\sigma$ and we had to estimate it with $s$, this bring and __extra element of uncertainty__
+- Because we didn't know $\sigma$ and we had to estimate it with $s$, this brings an __extra element of uncertainty__
 
 --
 

--- a/dapr1_lectures/dapr1_2_02_ht_pvalues/dapr1_2_02_ht_pvalues.Rmd
+++ b/dapr1_lectures/dapr1_2_02_ht_pvalues/dapr1_2_02_ht_pvalues.Rmd
@@ -889,7 +889,7 @@ p1 | p2 | p3
 
 
 ---
-# Guidelines for reporting strenght of evidence
+# Guidelines for reporting strength of evidence
 
 The following table summarizes in words the strength of evidence that the sample results bring in favour of the alternative hypothesis for different p-values:
 

--- a/dapr1_lectures/dapr1_2_05_errorspower/dapr1_2_05_errorspower.Rmd
+++ b/dapr1_lectures/dapr1_2_05_errorspower/dapr1_2_05_errorspower.Rmd
@@ -548,7 +548,7 @@ class: inverse, center, middle
 ---
 # Effect size
 
-- Effect size is related to the magnitude of the the difference between the true population mean $\mu$ and the hypothesised value $\mu_0$
+- Effect size is related to the magnitude of the difference between the true population mean $\mu$ and the hypothesised value $\mu_0$
 
 - We saw that a statistically significant result may not be important at all, i.e. may not have much real-world value.
     


### PR DESCRIPTION
Unhelpfully, the entire contents of `lec16` and `lec20` have been modified (if the files were developed on Windows, then maybe my editor changed the line endings?).

The only actual changes are:

`lec16`:

- Line 813 "Differece" -> "Difference"  https://github.com/elizabethpankratz/dapr1/commit/fd07eeb5de8261df576cd5a95871570dcef461cd#diff-da83b99bcdbc1ef471ed8348a3f05289a6a3e6c627b8b904be5ee795ff166e1dL813 


`lec20`:

- Line 142 "receded" -> "recorded"  https://github.com/elizabethpankratz/dapr1/commit/fd07eeb5de8261df576cd5a95871570dcef461cd#diff-1bc8db254d08c395bf51f04706b34b9cdddae98029b0839f0f30334498c67b79L142

- Line 1005: "hypotheses" -> "hypothesis"  https://github.com/elizabethpankratz/dapr1/commit/fd07eeb5de8261df576cd5a95871570dcef461cd#diff-1bc8db254d08c395bf51f04706b34b9cdddae98029b0839f0f30334498c67b79L1005


I only changed .Rmd files, so needs re-rendered.